### PR TITLE
fix: downgrade @react-email/components from 0.0.35 to 0.0.13 for compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
 				"@radix-ui/react-switch": "^1.1.3",
 				"@radix-ui/react-tabs": "^1.1.3",
 				"@radix-ui/react-tooltip": "^1.1.8",
-				"@react-email/components": "^0.0.35",
+				"@react-email/components": "^0.0.13",
 				"@react-email/render": "^1.0.5",
 				"bcryptjs": "^3.0.2",
 				"class-variance-authority": "^0.7.1",
@@ -1540,6 +1540,12 @@
 				"node": ">=12.4.0"
 			}
 		},
+		"node_modules/@one-ini/wasm": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+			"integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+			"license": "MIT"
+		},
 		"node_modules/@otplib/core": {
 			"version": "12.0.1",
 			"resolved": "https://registry.npmjs.org/@otplib/core/-/core-12.0.1.tgz",
@@ -2582,218 +2588,298 @@
 			"integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==",
 			"license": "MIT"
 		},
-		"node_modules/@react-email/body": {
-			"version": "0.0.11",
-			"resolved": "https://registry.npmjs.org/@react-email/body/-/body-0.0.11.tgz",
-			"integrity": "sha512-ZSD2SxVSgUjHGrB0Wi+4tu3MEpB4fYSbezsFNEJk2xCWDBkFiOeEsjTmR5dvi+CxTK691hQTQlHv0XWuP7ENTg==",
-			"license": "MIT",
-			"peerDependencies": {
-				"react": "^18.0 || ^19.0 || ^19.0.0-rc"
-			}
-		},
-		"node_modules/@react-email/button": {
-			"version": "0.0.19",
-			"resolved": "https://registry.npmjs.org/@react-email/button/-/button-0.0.19.tgz",
-			"integrity": "sha512-HYHrhyVGt7rdM/ls6FuuD6XE7fa7bjZTJqB2byn6/oGsfiEZaogY77OtoLL/mrQHjHjZiJadtAMSik9XLcm7+A==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.0.0"
-			},
-			"peerDependencies": {
-				"react": "^18.0 || ^19.0 || ^19.0.0-rc"
-			}
-		},
-		"node_modules/@react-email/code-block": {
-			"version": "0.0.11",
-			"resolved": "https://registry.npmjs.org/@react-email/code-block/-/code-block-0.0.11.tgz",
-			"integrity": "sha512-4D43p+LIMjDzm66gTDrZch0Flkip5je91mAT7iGs6+SbPyalHgIA+lFQoQwhz/VzHHLxuD0LV6gwmU/WUQ2WEg==",
-			"license": "MIT",
-			"dependencies": {
-				"prismjs": "1.29.0"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			},
-			"peerDependencies": {
-				"react": "^18.0 || ^19.0 || ^19.0.0-rc"
-			}
-		},
-		"node_modules/@react-email/code-inline": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/@react-email/code-inline/-/code-inline-0.0.5.tgz",
-			"integrity": "sha512-MmAsOzdJpzsnY2cZoPHFPk6uDO/Ncpb4Kh1hAt9UZc1xOW3fIzpe1Pi9y9p6wwUmpaeeDalJxAxH6/fnTquinA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.0.0"
-			},
-			"peerDependencies": {
-				"react": "^18.0 || ^19.0 || ^19.0.0-rc"
-			}
-		},
-		"node_modules/@react-email/column": {
-			"version": "0.0.13",
-			"resolved": "https://registry.npmjs.org/@react-email/column/-/column-0.0.13.tgz",
-			"integrity": "sha512-Lqq17l7ShzJG/d3b1w/+lVO+gp2FM05ZUo/nW0rjxB8xBICXOVv6PqjDnn3FXKssvhO5qAV20lHM6S+spRhEwQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.0.0"
-			},
-			"peerDependencies": {
-				"react": "^18.0 || ^19.0 || ^19.0.0-rc"
-			}
-		},
 		"node_modules/@react-email/components": {
-			"version": "0.0.35",
-			"resolved": "https://registry.npmjs.org/@react-email/components/-/components-0.0.35.tgz",
-			"integrity": "sha512-if1kLih4pfARgsXacs9eD9O3BVtRWxKRz1jjSWWiyk32eeFJLtWjBaoF8nsxQxk4w5nfqjAHVFBrxXQceB7xDQ==",
+			"version": "0.0.13",
+			"resolved": "https://registry.npmjs.org/@react-email/components/-/components-0.0.13.tgz",
+			"integrity": "sha512-7pFOGHYZcjKurmzjIi9h48bpcg/vW4PtnhRXS377iekZBThnIq6HyunWQTrIYZHAZ+75ehCCiMkw+QCXsuPl0A==",
 			"license": "MIT",
 			"dependencies": {
-				"@react-email/body": "0.0.11",
-				"@react-email/button": "0.0.19",
-				"@react-email/code-block": "0.0.11",
-				"@react-email/code-inline": "0.0.5",
-				"@react-email/column": "0.0.13",
-				"@react-email/container": "0.0.15",
-				"@react-email/font": "0.0.9",
-				"@react-email/head": "0.0.12",
-				"@react-email/heading": "0.0.15",
-				"@react-email/hr": "0.0.11",
-				"@react-email/html": "0.0.11",
-				"@react-email/img": "0.0.11",
-				"@react-email/link": "0.0.12",
-				"@react-email/markdown": "0.0.14",
-				"@react-email/preview": "0.0.12",
-				"@react-email/render": "1.0.5",
-				"@react-email/row": "0.0.12",
-				"@react-email/section": "0.0.16",
-				"@react-email/tailwind": "1.0.4",
-				"@react-email/text": "0.1.1"
+				"@react-email/body": "0.0.7",
+				"@react-email/button": "0.0.13",
+				"@react-email/column": "0.0.9",
+				"@react-email/container": "0.0.11",
+				"@react-email/font": "0.0.5",
+				"@react-email/head": "0.0.7",
+				"@react-email/heading": "0.0.11",
+				"@react-email/hr": "0.0.7",
+				"@react-email/html": "0.0.7",
+				"@react-email/img": "0.0.7",
+				"@react-email/link": "0.0.7",
+				"@react-email/preview": "0.0.8",
+				"@react-email/render": "0.0.11",
+				"@react-email/row": "0.0.7",
+				"@react-email/section": "0.0.11",
+				"@react-email/tailwind": "0.0.14",
+				"@react-email/text": "0.0.7"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			},
 			"peerDependencies": {
-				"react": "^18.0 || ^19.0 || ^19.0.0-rc"
+				"react": "18.2.0"
 			}
 		},
-		"node_modules/@react-email/container": {
-			"version": "0.0.15",
-			"resolved": "https://registry.npmjs.org/@react-email/container/-/container-0.0.15.tgz",
-			"integrity": "sha512-Qo2IQo0ru2kZq47REmHW3iXjAQaKu4tpeq/M8m1zHIVwKduL2vYOBQWbC2oDnMtWPmkBjej6XxgtZByxM6cCFg==",
+		"node_modules/@react-email/components/node_modules/@react-email/body": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/@react-email/body/-/body-0.0.7.tgz",
+			"integrity": "sha512-vjJ5P1MUNWV0KNivaEWA6MGj/I3c764qQJMsKjCHlW6mkFJ4SXbm2OlQFtKAb++Bj8LDqBlnE6oW77bWcMc0NA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"react": "18.2.0"
+			}
+		},
+		"node_modules/@react-email/components/node_modules/@react-email/button": {
+			"version": "0.0.13",
+			"resolved": "https://registry.npmjs.org/@react-email/button/-/button-0.0.13.tgz",
+			"integrity": "sha512-e/y8u2odJ8fF83B+wvL2FXzVcbQSUh2Cn2JH2Ez4L6AuPELsh8s2JYo081IDsXc16IyFiYpObn0blOt7s/qp8g==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18.0.0"
 			},
 			"peerDependencies": {
-				"react": "^18.0 || ^19.0 || ^19.0.0-rc"
+				"react": "18.2.0"
 			}
 		},
-		"node_modules/@react-email/font": {
+		"node_modules/@react-email/components/node_modules/@react-email/column": {
 			"version": "0.0.9",
-			"resolved": "https://registry.npmjs.org/@react-email/font/-/font-0.0.9.tgz",
-			"integrity": "sha512-4zjq23oT9APXkerqeslPH3OZWuh5X4crHK6nx82mVHV2SrLba8+8dPEnWbaACWTNjOCbcLIzaC9unk7Wq2MIXw==",
-			"license": "MIT",
-			"peerDependencies": {
-				"react": "^18.0 || ^19.0 || ^19.0.0-rc"
-			}
-		},
-		"node_modules/@react-email/head": {
-			"version": "0.0.12",
-			"resolved": "https://registry.npmjs.org/@react-email/head/-/head-0.0.12.tgz",
-			"integrity": "sha512-X2Ii6dDFMF+D4niNwMAHbTkeCjlYYnMsd7edXOsi0JByxt9wNyZ9EnhFiBoQdqkE+SMDcu8TlNNttMrf5sJeMA==",
+			"resolved": "https://registry.npmjs.org/@react-email/column/-/column-0.0.9.tgz",
+			"integrity": "sha512-1ekqNBgmbS6m97/sUFOnVvQtLYljUWamw8Y44VId95v6SjiJ4ca+hMcdOteHWBH67xkRofEOWTvqDRea5SBV8w==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18.0.0"
 			},
 			"peerDependencies": {
-				"react": "^18.0 || ^19.0 || ^19.0.0-rc"
+				"react": "18.2.0"
 			}
 		},
-		"node_modules/@react-email/heading": {
-			"version": "0.0.15",
-			"resolved": "https://registry.npmjs.org/@react-email/heading/-/heading-0.0.15.tgz",
-			"integrity": "sha512-xF2GqsvBrp/HbRHWEfOgSfRFX+Q8I5KBEIG5+Lv3Vb2R/NYr0s8A5JhHHGf2pWBMJdbP4B2WHgj/VUrhy8dkIg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.0.0"
-			},
-			"peerDependencies": {
-				"react": "^18.0 || ^19.0 || ^19.0.0-rc"
-			}
-		},
-		"node_modules/@react-email/hr": {
+		"node_modules/@react-email/components/node_modules/@react-email/container": {
 			"version": "0.0.11",
-			"resolved": "https://registry.npmjs.org/@react-email/hr/-/hr-0.0.11.tgz",
-			"integrity": "sha512-S1gZHVhwOsd1Iad5IFhpfICwNPMGPJidG/Uysy1AwmspyoAP5a4Iw3OWEpINFdgh9MHladbxcLKO2AJO+cA9Lw==",
+			"resolved": "https://registry.npmjs.org/@react-email/container/-/container-0.0.11.tgz",
+			"integrity": "sha512-jzl/EHs0ClXIRFamfH+NR/cqv4GsJJscqRhdYtnWYuRAsWpKBM1muycrrPqIVhWvWi6sFHInWTt07jX+bDc3SQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18.0.0"
 			},
 			"peerDependencies": {
-				"react": "^18.0 || ^19.0 || ^19.0.0-rc"
+				"react": "18.2.0"
 			}
 		},
-		"node_modules/@react-email/html": {
+		"node_modules/@react-email/components/node_modules/@react-email/font": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/@react-email/font/-/font-0.0.5.tgz",
+			"integrity": "sha512-if/qKYmH3rJ2egQJoKbV8SfKCPavu+ikUq/naT/UkCr8Q0lkk309tRA0x7fXG/WeIrmcipjMzFRGTm2TxTecDw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"react": "18.2.0"
+			}
+		},
+		"node_modules/@react-email/components/node_modules/@react-email/head": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/@react-email/head/-/head-0.0.7.tgz",
+			"integrity": "sha512-IcXL4jc0H1qzAXJCD9ajcRFBQdbUHkjKJyiUeogpaYSVZSq6cVDWQuGaI23TA9k+pI2TFeQimogUFb3Kgeeudw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"react": "18.2.0"
+			}
+		},
+		"node_modules/@react-email/components/node_modules/@react-email/heading": {
 			"version": "0.0.11",
-			"resolved": "https://registry.npmjs.org/@react-email/html/-/html-0.0.11.tgz",
-			"integrity": "sha512-qJhbOQy5VW5qzU74AimjAR9FRFQfrMa7dn4gkEXKMB/S9xZN8e1yC1uA9C15jkXI/PzmJ0muDIWmFwatm5/+VA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.0.0"
-			},
-			"peerDependencies": {
-				"react": "^18.0 || ^19.0 || ^19.0.0-rc"
-			}
-		},
-		"node_modules/@react-email/img": {
-			"version": "0.0.11",
-			"resolved": "https://registry.npmjs.org/@react-email/img/-/img-0.0.11.tgz",
-			"integrity": "sha512-aGc8Y6U5C3igoMaqAJKsCpkbm1XjguQ09Acd+YcTKwjnC2+0w3yGUJkjWB2vTx4tN8dCqQCXO8FmdJpMfOA9EQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.0.0"
-			},
-			"peerDependencies": {
-				"react": "^18.0 || ^19.0 || ^19.0.0-rc"
-			}
-		},
-		"node_modules/@react-email/link": {
-			"version": "0.0.12",
-			"resolved": "https://registry.npmjs.org/@react-email/link/-/link-0.0.12.tgz",
-			"integrity": "sha512-vF+xxQk2fGS1CN7UPQDbzvcBGfffr+GjTPNiWM38fhBfsLv6A/YUfaqxWlmL7zLzVmo0K2cvvV9wxlSyNba1aQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.0.0"
-			},
-			"peerDependencies": {
-				"react": "^18.0 || ^19.0 || ^19.0.0-rc"
-			}
-		},
-		"node_modules/@react-email/markdown": {
-			"version": "0.0.14",
-			"resolved": "https://registry.npmjs.org/@react-email/markdown/-/markdown-0.0.14.tgz",
-			"integrity": "sha512-5IsobCyPkb4XwnQO8uFfGcNOxnsg3311GRXhJ3uKv51P7Jxme4ycC/MITnwIZ10w2zx7HIyTiqVzTj4XbuIHbg==",
+			"resolved": "https://registry.npmjs.org/@react-email/heading/-/heading-0.0.11.tgz",
+			"integrity": "sha512-EF5ZtRCxhHPw3m+8iibKKg0RAvAeHj1AP68sjU7s6+J+kvRgllr/E972Wi5Y8UvcIGossCvpX1WrSMDzeB4puA==",
 			"license": "MIT",
 			"dependencies": {
-				"md-to-react-email": "5.0.5"
+				"@radix-ui/react-slot": "1.0.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			},
 			"peerDependencies": {
-				"react": "^18.0 || ^19.0 || ^19.0.0-rc"
+				"react": "18.2.0"
 			}
 		},
-		"node_modules/@react-email/preview": {
-			"version": "0.0.12",
-			"resolved": "https://registry.npmjs.org/@react-email/preview/-/preview-0.0.12.tgz",
-			"integrity": "sha512-g/H5fa9PQPDK6WUEG7iTlC19sAktI23qyoiJtMLqQiXFCfWeQMhqjLGKeLSKkfzszqmfJCjZtpSiKtBoOdxp3Q==",
+		"node_modules/@react-email/components/node_modules/@react-email/heading/node_modules/@radix-ui/react-slot": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
+			"integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-compose-refs": "1.0.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@react-email/components/node_modules/@react-email/heading/node_modules/@radix-ui/react-slot/node_modules/@radix-ui/react-compose-refs": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
+			"integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@react-email/components/node_modules/@react-email/hr": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/@react-email/hr/-/hr-0.0.7.tgz",
+			"integrity": "sha512-8suK0M/deXHt0DBSeKhSC4bnCBCBm37xk6KJh9M0/FIKlvdltQBem52YUiuqVl1XLB87Y6v6tvspn3SZ9fuxEA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18.0.0"
 			},
 			"peerDependencies": {
-				"react": "^18.0 || ^19.0 || ^19.0.0-rc"
+				"react": "18.2.0"
+			}
+		},
+		"node_modules/@react-email/components/node_modules/@react-email/html": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/@react-email/html/-/html-0.0.7.tgz",
+			"integrity": "sha512-oy7OoRtoOKApVI/5Lz1OZptMKmMYJu9Xn6+lOmdBQchAuSdQtWJqxhrSj/iI/mm8HZWo6MZEQ6SFpfOuf8/P6Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"react": "18.2.0"
+			}
+		},
+		"node_modules/@react-email/components/node_modules/@react-email/img": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/@react-email/img/-/img-0.0.7.tgz",
+			"integrity": "sha512-up9tM2/dJ24u/CFjcvioKbyGuPw1yeJg605QA7VkrygEhd0CoQEjjgumfugpJ+VJgIt4ZjT9xMVCK5QWTIWoaA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"react": "18.2.0"
+			}
+		},
+		"node_modules/@react-email/components/node_modules/@react-email/link": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/@react-email/link/-/link-0.0.7.tgz",
+			"integrity": "sha512-hXPChT3ZMyKnUSA60BLEMD2maEgyB2A37yg5bASbLMrXmsExHi6/IS1h2XiUPLDK4KqH5KFaFxi2cdNo1JOKwA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"react": "18.2.0"
+			}
+		},
+		"node_modules/@react-email/components/node_modules/@react-email/preview": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/@react-email/preview/-/preview-0.0.8.tgz",
+			"integrity": "sha512-Jm0KUYBZQd2w0s2QRMQy0zfHdo3Ns+9bYSE1OybjknlvhANirjuZw9E5KfWgdzO7PyrRtB1OBOQD8//Obc4uIQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"react": "18.2.0"
+			}
+		},
+		"node_modules/@react-email/components/node_modules/@react-email/render": {
+			"version": "0.0.11",
+			"resolved": "https://registry.npmjs.org/@react-email/render/-/render-0.0.11.tgz",
+			"integrity": "sha512-Ec4vLkVbxoQhThBK1H++FdO4NgCeucg57qmwQ8A9xbozA2hWJiT2jJb5IA/bLE0YdixK8BeucXghJp84YZIG7A==",
+			"license": "MIT",
+			"dependencies": {
+				"html-to-text": "9.0.5",
+				"js-beautify": "^1.14.11",
+				"react": "18.2.0",
+				"react-dom": "18.2.0"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@react-email/components/node_modules/@react-email/render/node_modules/react": {
+			"version": "18.2.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+			"integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+			"license": "MIT",
+			"dependencies": {
+				"loose-envify": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@react-email/components/node_modules/@react-email/render/node_modules/react-dom": {
+			"version": "18.2.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+			"integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+			"license": "MIT",
+			"dependencies": {
+				"loose-envify": "^1.1.0",
+				"scheduler": "^0.23.0"
+			},
+			"peerDependencies": {
+				"react": "^18.2.0"
+			}
+		},
+		"node_modules/@react-email/components/node_modules/@react-email/row": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/@react-email/row/-/row-0.0.7.tgz",
+			"integrity": "sha512-h7pwrLVGk5CIx7Ai/oPxBgCCAGY7BEpCUQ7FCzi4+eThcs5IdjSwDPefLEkwaFS8KZc56UNwTAH92kNq5B7blg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"react": "18.2.0"
+			}
+		},
+		"node_modules/@react-email/components/node_modules/@react-email/section": {
+			"version": "0.0.11",
+			"resolved": "https://registry.npmjs.org/@react-email/section/-/section-0.0.11.tgz",
+			"integrity": "sha512-3bZ/DuvX1julATI7oqYza6pOtWZgLJDBaa62LFFEvYjisyN+k6lrP2KOucPsDKu2DOkUzlQgK0FOm6VQJX+C0w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"react": "18.2.0"
+			}
+		},
+		"node_modules/@react-email/components/node_modules/@react-email/text": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/@react-email/text/-/text-0.0.7.tgz",
+			"integrity": "sha512-eHCx0mdllGcgK9X7wiLKjNZCBRfxRVNjD3NNYRmOc3Icbl8M9JHriJIfxBuGCmGg2UAORK5P3KmaLQ8b99/pbA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"react": "18.2.0"
+			}
+		},
+		"node_modules/@react-email/components/node_modules/scheduler": {
+			"version": "0.23.2",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+			"integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+			"license": "MIT",
+			"dependencies": {
+				"loose-envify": "^1.1.0"
 			}
 		},
 		"node_modules/@react-email/render": {
@@ -2814,52 +2900,31 @@
 				"react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
 			}
 		},
-		"node_modules/@react-email/row": {
-			"version": "0.0.12",
-			"resolved": "https://registry.npmjs.org/@react-email/row/-/row-0.0.12.tgz",
-			"integrity": "sha512-HkCdnEjvK3o+n0y0tZKXYhIXUNPDx+2vq1dJTmqappVHXS5tXS6W5JOPZr5j+eoZ8gY3PShI2LWj5rWF7ZEtIQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.0.0"
-			},
-			"peerDependencies": {
-				"react": "^18.0 || ^19.0 || ^19.0.0-rc"
-			}
-		},
-		"node_modules/@react-email/section": {
-			"version": "0.0.16",
-			"resolved": "https://registry.npmjs.org/@react-email/section/-/section-0.0.16.tgz",
-			"integrity": "sha512-FjqF9xQ8FoeUZYKSdt8sMIKvoT9XF8BrzhT3xiFKdEMwYNbsDflcjfErJe3jb7Wj/es/lKTbV5QR1dnLzGpL3w==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.0.0"
-			},
-			"peerDependencies": {
-				"react": "^18.0 || ^19.0 || ^19.0.0-rc"
-			}
-		},
 		"node_modules/@react-email/tailwind": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@react-email/tailwind/-/tailwind-1.0.4.tgz",
-			"integrity": "sha512-tJdcusncdqgvTUYZIuhNC6LYTfL9vNTSQpwWdTCQhQ1lsrNCEE4OKCSdzSV3S9F32pi0i0xQ+YPJHKIzGjdTSA==",
+			"version": "0.0.14",
+			"resolved": "https://registry.npmjs.org/@react-email/tailwind/-/tailwind-0.0.14.tgz",
+			"integrity": "sha512-SRRcm08zxrAR5XozaW0X+GAJlTJITakZe0UXBiFZDlSDBLwFMxjaGuQwccqNF0LxDnxmduxYB71mzEAqecgTZg==",
 			"license": "MIT",
+			"dependencies": {
+				"react": "18.2.0"
+			},
 			"engines": {
 				"node": ">=18.0.0"
 			},
 			"peerDependencies": {
-				"react": "^18.0 || ^19.0 || ^19.0.0-rc"
+				"react": "18.2.0"
 			}
 		},
-		"node_modules/@react-email/text": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/@react-email/text/-/text-0.1.1.tgz",
-			"integrity": "sha512-Zo9tSEzkO3fODLVH1yVhzVCiwETfeEL5wU93jXKWo2DHoMuiZ9Iabaso3T0D0UjhrCB1PBMeq2YiejqeToTyIQ==",
+		"node_modules/@react-email/tailwind/node_modules/react": {
+			"version": "18.2.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+			"integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
 			"license": "MIT",
-			"engines": {
-				"node": ">=18.0.0"
+			"dependencies": {
+				"loose-envify": "^1.1.0"
 			},
-			"peerDependencies": {
-				"react": "^18.0 || ^19.0 || ^19.0.0-rc"
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/@rtsao/scc": {
@@ -3224,7 +3289,7 @@
 			"version": "19.0.10",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
 			"integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"csstype": "^3.0.2"
@@ -3234,7 +3299,7 @@
 			"version": "19.0.4",
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.0.4.tgz",
 			"integrity": "sha512-4fSQ8vWFkg+TGhePfUzVmat3eC14TXYSsiiDSLI0dVLsrm9gZFABjPy/Qu6TKgl1tq1Bu1yDsuQgY3A3DOjCcg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"@types/react": "^19.0.0"
@@ -3474,6 +3539,15 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/abbrev": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+			"integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
 		"node_modules/accepts": {
@@ -4161,6 +4235,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/config-chain": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+			"integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ini": "^1.3.4",
+				"proto-list": "~1.2.1"
+			}
+		},
 		"node_modules/cookie": {
 			"version": "0.7.2",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
@@ -4479,6 +4563,57 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/editorconfig": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.4.tgz",
+			"integrity": "sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@one-ini/wasm": "0.1.1",
+				"commander": "^10.0.0",
+				"minimatch": "9.0.1",
+				"semver": "^7.5.3"
+			},
+			"bin": {
+				"editorconfig": "bin/editorconfig"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/editorconfig/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/editorconfig/node_modules/commander": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+			"integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/editorconfig/node_modules/minimatch": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
+			"integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/emoji-regex": {
@@ -5831,6 +5966,12 @@
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"license": "ISC"
 		},
+		"node_modules/ini": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+			"license": "ISC"
+		},
 		"node_modules/internal-slot": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -6339,6 +6480,95 @@
 				"url": "https://github.com/sponsors/panva"
 			}
 		},
+		"node_modules/js-beautify": {
+			"version": "1.15.4",
+			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+			"integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+			"license": "MIT",
+			"dependencies": {
+				"config-chain": "^1.1.13",
+				"editorconfig": "^1.0.4",
+				"glob": "^10.4.2",
+				"js-cookie": "^3.0.5",
+				"nopt": "^7.2.1"
+			},
+			"bin": {
+				"css-beautify": "js/bin/css-beautify.js",
+				"html-beautify": "js/bin/html-beautify.js",
+				"js-beautify": "js/bin/js-beautify.js"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/js-beautify/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/js-beautify/node_modules/glob": {
+			"version": "10.4.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/js-beautify/node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
+		"node_modules/js-beautify/node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/js-cookie": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+			"integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6840,7 +7070,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
@@ -6870,18 +7099,6 @@
 				"react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
-		"node_modules/marked": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-7.0.4.tgz",
-			"integrity": "sha512-t8eP0dXRJMtMvBojtkcsA7n48BkauktUKzfkPSCq85ZMTJ0v76Rke4DYz01omYpPTUh4p/f7HePgRo3ebG8+QQ==",
-			"license": "MIT",
-			"bin": {
-				"marked": "bin/marked.js"
-			},
-			"engines": {
-				"node": ">= 16"
-			}
-		},
 		"node_modules/math-intrinsics": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -6890,18 +7107,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/md-to-react-email": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/md-to-react-email/-/md-to-react-email-5.0.5.tgz",
-			"integrity": "sha512-OvAXqwq57uOk+WZqFFNCMZz8yDp8BD3WazW1wAKHUrPbbdr89K9DWS6JXY09vd9xNdPNeurI8DU/X4flcfaD8A==",
-			"license": "MIT",
-			"dependencies": {
-				"marked": "7.0.4"
-			},
-			"peerDependencies": {
-				"react": "^18.0 || ^19.0"
 			}
 		},
 		"node_modules/merge2": {
@@ -7151,6 +7356,21 @@
 			"license": "MIT-0",
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/nopt": {
+			"version": "7.2.1",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+			"integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+			"license": "ISC",
+			"dependencies": {
+				"abbrev": "^2.0.0"
+			},
+			"bin": {
+				"nopt": "bin/nopt.js"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
 		"node_modules/normalize-path": {
@@ -7460,6 +7680,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/package-json-from-dist": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+			"license": "BlueOak-1.0.0"
+		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7682,15 +7908,6 @@
 				}
 			}
 		},
-		"node_modules/prismjs": {
-			"version": "1.29.0",
-			"resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-			"integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/prop-types": {
 			"version": "15.8.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -7702,6 +7919,12 @@
 				"object-assign": "^4.1.1",
 				"react-is": "^16.13.1"
 			}
+		},
+		"node_modules/proto-list": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+			"integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+			"license": "ISC"
 		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
@@ -9481,7 +9704,6 @@
 			"version": "4.0.12",
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.12.tgz",
 			"integrity": "sha512-bT0hJo91FtncsAMSsMzUkoo/iEU0Xs5xgFgVC9XmdM9bw5MhZuQFjPNl6wxAE0SiQF/YTZJa+PndGWYSDtuxAg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/tailwindcss-animate": {
@@ -9696,7 +9918,7 @@
 			"version": "5.8.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
 			"integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"@radix-ui/react-switch": "^1.1.3",
 		"@radix-ui/react-tabs": "^1.1.3",
 		"@radix-ui/react-tooltip": "^1.1.8",
-		"@react-email/components": "^0.0.35",
+		"@react-email/components": "^0.0.13",
 		"@react-email/render": "^1.0.5",
 		"bcryptjs": "^3.0.2",
 		"class-variance-authority": "^0.7.1",


### PR DESCRIPTION
This pull request includes a version downgrade for the `@react-email/components` package in the `package.json` file.

Dependency changes:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L29-R29): Downgraded `@react-email/components` from version `^0.0.35` to `^0.0.13`.