### PR TITLE
chore: update next.js to version 15.3.1 in package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
 				"jsonwebtoken": "^9.0.2",
 				"lodash": "^4.17.21",
 				"lucide-react": "^0.479.0",
-				"next": "^15.3.0",
+				"next": "^15.3.1",
 				"next-auth": "^4.24.11",
 				"next-theme": "^0.1.5",
 				"next-themes": "^0.4.6",
@@ -2284,9 +2284,9 @@
 			}
 		},
 		"node_modules/@next/env": {
-			"version": "15.3.0",
-			"resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.0.tgz",
-			"integrity": "sha512-6mDmHX24nWlHOlbwUiAOmMyY7KELimmi+ed8qWcJYjqXeC+G6JzPZ3QosOAfjNwgMIzwhXBiRiCgdh8axTTdTA==",
+			"version": "15.3.1",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.1.tgz",
+			"integrity": "sha512-cwK27QdzrMblHSn9DZRV+DQscHXRuJv6MydlJRpFSqJWZrTYMLzKDeyueJNN9MGd8NNiUKzDQADAf+dMLXX7YQ==",
 			"license": "MIT"
 		},
 		"node_modules/@next/eslint-plugin-next": {
@@ -2300,9 +2300,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-arm64": {
-			"version": "15.3.0",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.3.0.tgz",
-			"integrity": "sha512-PDQcByT0ZfF2q7QR9d+PNj3wlNN4K6Q8JoHMwFyk252gWo4gKt7BF8Y2+KBgDjTFBETXZ/TkBEUY7NIIY7A/Kw==",
+			"version": "15.3.1",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.3.1.tgz",
+			"integrity": "sha512-hjDw4f4/nla+6wysBL07z52Gs55Gttp5Bsk5/8AncQLJoisvTBP0pRIBK/B16/KqQyH+uN4Ww8KkcAqJODYH3w==",
 			"cpu": [
 				"arm64"
 			],
@@ -2316,9 +2316,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-x64": {
-			"version": "15.3.0",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.0.tgz",
-			"integrity": "sha512-m+eO21yg80En8HJ5c49AOQpFDq+nP51nu88ZOMCorvw3g//8g1JSUsEiPSiFpJo1KCTQ+jm9H0hwXK49H/RmXg==",
+			"version": "15.3.1",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.1.tgz",
+			"integrity": "sha512-q+aw+cJ2ooVYdCEqZVk+T4Ni10jF6Fo5DfpEV51OupMaV5XL6pf3GCzrk6kSSZBsMKZtVC1Zm/xaNBFpA6bJ2g==",
 			"cpu": [
 				"x64"
 			],
@@ -2332,9 +2332,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-gnu": {
-			"version": "15.3.0",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.0.tgz",
-			"integrity": "sha512-H0Kk04ZNzb6Aq/G6e0un4B3HekPnyy6D+eUBYPJv9Abx8KDYgNMWzKt4Qhj57HXV3sTTjsfc1Trc1SxuhQB+Tg==",
+			"version": "15.3.1",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.1.tgz",
+			"integrity": "sha512-wBQ+jGUI3N0QZyWmmvRHjXjTWFy8o+zPFLSOyAyGFI94oJi+kK/LIZFJXeykvgXUk1NLDAEFDZw/NVINhdk9FQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -2348,9 +2348,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-musl": {
-			"version": "15.3.0",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.0.tgz",
-			"integrity": "sha512-k8GVkdMrh/+J9uIv/GpnHakzgDQhrprJ/FbGQvwWmstaeFG06nnAoZCJV+wO/bb603iKV1BXt4gHG+s2buJqZA==",
+			"version": "15.3.1",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.1.tgz",
+			"integrity": "sha512-IIxXEXRti/AulO9lWRHiCpUUR8AR/ZYLPALgiIg/9ENzMzLn3l0NSxVdva7R/VDcuSEBo0eGVCe3evSIHNz0Hg==",
 			"cpu": [
 				"arm64"
 			],
@@ -2364,9 +2364,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-gnu": {
-			"version": "15.3.0",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.0.tgz",
-			"integrity": "sha512-ZMQ9yzDEts/vkpFLRAqfYO1wSpIJGlQNK9gZ09PgyjBJUmg8F/bb8fw2EXKgEaHbCc4gmqMpDfh+T07qUphp9A==",
+			"version": "15.3.1",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.1.tgz",
+			"integrity": "sha512-bfI4AMhySJbyXQIKH5rmLJ5/BP7bPwuxauTvVEiJ/ADoddaA9fgyNNCcsbu9SlqfHDoZmfI6g2EjzLwbsVTr5A==",
 			"cpu": [
 				"x64"
 			],
@@ -2380,9 +2380,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-musl": {
-			"version": "15.3.0",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.0.tgz",
-			"integrity": "sha512-RFwq5VKYTw9TMr4T3e5HRP6T4RiAzfDJ6XsxH8j/ZeYq2aLsBqCkFzwMI0FmnSsLaUbOb46Uov0VvN3UciHX5A==",
+			"version": "15.3.1",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.1.tgz",
+			"integrity": "sha512-FeAbR7FYMWR+Z+M5iSGytVryKHiAsc0x3Nc3J+FD5NVbD5Mqz7fTSy8CYliXinn7T26nDMbpExRUI/4ekTvoiA==",
 			"cpu": [
 				"x64"
 			],
@@ -2396,9 +2396,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-arm64-msvc": {
-			"version": "15.3.0",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.0.tgz",
-			"integrity": "sha512-a7kUbqa/k09xPjfCl0RSVAvEjAkYBYxUzSVAzk2ptXiNEL+4bDBo9wNC43G/osLA/EOGzG4CuNRFnQyIHfkRgQ==",
+			"version": "15.3.1",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.1.tgz",
+			"integrity": "sha512-yP7FueWjphQEPpJQ2oKmshk/ppOt+0/bB8JC8svPUZNy0Pi3KbPx2Llkzv1p8CoQa+D2wknINlJpHf3vtChVBw==",
 			"cpu": [
 				"arm64"
 			],
@@ -2412,9 +2412,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-x64-msvc": {
-			"version": "15.3.0",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.0.tgz",
-			"integrity": "sha512-vHUQS4YVGJPmpjn7r5lEZuMhK5UQBNBRSB+iGDvJjaNk649pTIcRluDWNb9siunyLLiu/LDPHfvxBtNamyuLTw==",
+			"version": "15.3.1",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.1.tgz",
+			"integrity": "sha512-3PMvF2zRJAifcRNni9uMk/gulWfWS+qVI/pagd+4yLF5bcXPZPPH2xlYRYOsUjmCJOXSTAC2PjRzbhsRzR2fDQ==",
 			"cpu": [
 				"x64"
 			],
@@ -9536,12 +9536,12 @@
 			}
 		},
 		"node_modules/next": {
-			"version": "15.3.0",
-			"resolved": "https://registry.npmjs.org/next/-/next-15.3.0.tgz",
-			"integrity": "sha512-k0MgP6BsK8cZ73wRjMazl2y2UcXj49ZXLDEgx6BikWuby/CN+nh81qFFI16edgd7xYpe/jj2OZEIwCoqnzz0bQ==",
+			"version": "15.3.1",
+			"resolved": "https://registry.npmjs.org/next/-/next-15.3.1.tgz",
+			"integrity": "sha512-8+dDV0xNLOgHlyBxP1GwHGVaNXsmp+2NhZEYrXr24GWLHtt27YrBPbPuHvzlhi7kZNYjeJNR93IF5zfFu5UL0g==",
 			"license": "MIT",
 			"dependencies": {
-				"@next/env": "15.3.0",
+				"@next/env": "15.3.1",
 				"@swc/counter": "0.1.3",
 				"@swc/helpers": "0.5.15",
 				"busboy": "1.6.0",
@@ -9556,14 +9556,14 @@
 				"node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
 			},
 			"optionalDependencies": {
-				"@next/swc-darwin-arm64": "15.3.0",
-				"@next/swc-darwin-x64": "15.3.0",
-				"@next/swc-linux-arm64-gnu": "15.3.0",
-				"@next/swc-linux-arm64-musl": "15.3.0",
-				"@next/swc-linux-x64-gnu": "15.3.0",
-				"@next/swc-linux-x64-musl": "15.3.0",
-				"@next/swc-win32-arm64-msvc": "15.3.0",
-				"@next/swc-win32-x64-msvc": "15.3.0",
+				"@next/swc-darwin-arm64": "15.3.1",
+				"@next/swc-darwin-x64": "15.3.1",
+				"@next/swc-linux-arm64-gnu": "15.3.1",
+				"@next/swc-linux-arm64-musl": "15.3.1",
+				"@next/swc-linux-x64-gnu": "15.3.1",
+				"@next/swc-linux-x64-musl": "15.3.1",
+				"@next/swc-win32-arm64-msvc": "15.3.1",
+				"@next/swc-win32-x64-msvc": "15.3.1",
 				"sharp": "^0.34.1"
 			},
 			"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"jsonwebtoken": "^9.0.2",
 		"lodash": "^4.17.21",
 		"lucide-react": "^0.479.0",
-		"next": "^15.3.0",
+		"next": "^15.3.1",
 		"next-auth": "^4.24.11",
 		"next-theme": "^0.1.5",
 		"next-themes": "^0.4.6",


### PR DESCRIPTION
This pull request includes a minor dependency update in the `package.json` file. The `next` package has been updated from version `^15.3.0` to `^15.3.1`.